### PR TITLE
[dyad] Redesign settings page with tabs - wrote 2 file(s)

### DIFF
--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -1,8 +1,100 @@
+import { Separator } from "@/components/ui/separator"
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+import { Button } from "@/components/ui/button"
+import { Checkbox } from "@/components/ui/checkbox"
+import { AppearanceForm } from "@/components/appearance-form"
+
 export default function SettingsPage() {
   return (
     <div className="flex-1 space-y-4 p-8 pt-6">
-      <h2 className="text-3xl font-bold tracking-tight">Settings</h2>
-      <p>Settings page is under construction.</p>
+      <div className="space-y-0.5">
+        <h2 className="text-3xl font-bold tracking-tight">Settings</h2>
+        <p className="text-muted-foreground">
+          Manage your account settings and set your preferences.
+        </p>
+      </div>
+      <Separator className="my-6" />
+      <Tabs defaultValue="profile" className="space-y-4">
+        <TabsList>
+          <TabsTrigger value="profile">Profile</TabsTrigger>
+          <TabsTrigger value="appearance">Appearance</TabsTrigger>
+          <TabsTrigger value="notifications">Notifications</TabsTrigger>
+        </TabsList>
+        <TabsContent value="profile" className="space-y-4">
+          <Card>
+            <CardHeader>
+              <CardTitle>Profile</CardTitle>
+              <CardDescription>
+                This is how others will see you on the site.
+              </CardDescription>
+            </CardHeader>
+            <CardContent className="space-y-4">
+              <div className="space-y-2">
+                <Label htmlFor="name">Name</Label>
+                <Input id="name" defaultValue="John Doe" />
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="email">Email</Label>
+                <Input
+                  id="email"
+                  type="email"
+                  defaultValue="john.doe@example.com"
+                  disabled
+                />
+              </div>
+            </CardContent>
+            <CardFooter>
+              <Button>Save changes</Button>
+            </CardFooter>
+          </Card>
+        </TabsContent>
+        <TabsContent value="appearance" className="space-y-4">
+          <AppearanceForm />
+        </TabsContent>
+        <TabsContent value="notifications" className="space-y-4">
+          <Card>
+            <CardHeader>
+              <CardTitle>Notifications</CardTitle>
+              <CardDescription>
+                Configure how you receive notifications.
+              </CardDescription>
+            </CardHeader>
+            <CardContent className="grid gap-6">
+              <div className="flex flex-row items-center justify-between rounded-lg border p-4">
+                <div className="space-y-0.5">
+                  <Label className="text-base">Communication emails</Label>
+                  <p className="text-sm text-muted-foreground">
+                    Receive emails about your account activity.
+                  </p>
+                </div>
+                <Checkbox defaultChecked />
+              </div>
+              <div className="flex flex-row items-center justify-between rounded-lg border p-4">
+                <div className="space-y-0.5">
+                  <Label className="text-base">Marketing emails</Label>
+                  <p className="text-sm text-muted-foreground">
+                    Receive emails about new products, features, and more.
+                  </p>
+                </div>
+                <Checkbox />
+              </div>
+            </CardContent>
+            <CardFooter>
+              <Button>Save preferences</Button>
+            </CardFooter>
+          </Card>
+        </TabsContent>
+      </Tabs>
     </div>
   )
 }

--- a/src/components/appearance-form.tsx
+++ b/src/components/appearance-form.tsx
@@ -1,0 +1,168 @@
+"use client"
+
+import { zodResolver } from "@hookform/resolvers/zod"
+import { useForm } from "react-hook-form"
+import { z } from "zod"
+import { useTheme } from "next-themes"
+import { toast } from "sonner"
+
+import { Button } from "@/components/ui/button"
+import {
+  Form,
+  FormControl,
+  FormDescription,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@/components/ui/form"
+import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group"
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card"
+
+const appearanceFormSchema = z.object({
+  theme: z.enum(["light", "dark", "system"], {
+    required_error: "Please select a theme.",
+  }),
+})
+
+type AppearanceFormValues = z.infer<typeof appearanceFormSchema>
+
+export function AppearanceForm() {
+  const { setTheme, theme } = useTheme()
+
+  const form = useForm<AppearanceFormValues>({
+    resolver: zodResolver(appearanceFormSchema),
+    defaultValues: {
+      theme: (theme as AppearanceFormValues["theme"]) || "system",
+    },
+  })
+
+  function onSubmit(data: AppearanceFormValues) {
+    setTheme(data.theme)
+    toast("Theme updated!", {
+      description: "Your theme settings have been successfully saved.",
+    })
+  }
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Appearance</CardTitle>
+        <CardDescription>
+          Customize the appearance of the app. Automatically switch between day
+          and night themes.
+        </CardDescription>
+      </CardHeader>
+      <CardContent>
+        <Form {...form}>
+          <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-8">
+            <FormField
+              control={form.control}
+              name="theme"
+              render={({ field }) => (
+                <FormItem className="space-y-1">
+                  <FormLabel>Theme</FormLabel>
+                  <FormDescription>
+                    Select the theme for the dashboard.
+                  </FormDescription>
+                  <FormMessage />
+                  <RadioGroup
+                    onValueChange={field.onChange}
+                    defaultValue={field.value}
+                    className="grid max-w-md grid-cols-1 gap-4 pt-2 sm:grid-cols-3"
+                  >
+                    <FormItem>
+                      <FormLabel className="[&:has([data-state=checked])>div]:border-primary">
+                        <FormControl>
+                          <RadioGroupItem value="light" className="sr-only" />
+                        </FormControl>
+                        <div className="items-center rounded-md border-2 border-muted p-1 hover:border-accent">
+                          <div className="space-y-2 rounded-sm bg-[#ecedef] p-2">
+                            <div className="space-y-2 rounded-md bg-white p-2 shadow-sm">
+                              <div className="h-2 w-[80px] rounded-lg bg-[#ecedef]" />
+                              <div className="h-2 w-[100px] rounded-lg bg-[#ecedef]" />
+                            </div>
+                            <div className="flex items-center space-x-2 rounded-md bg-white p-2 shadow-sm">
+                              <div className="h-4 w-4 rounded-full bg-[#ecedef]" />
+                              <div className="h-2 w-[100px] rounded-lg bg-[#ecedef]" />
+                            </div>
+                            <div className="flex items-center space-x-2 rounded-md bg-white p-2 shadow-sm">
+                              <div className="h-4 w-4 rounded-full bg-[#ecedef]" />
+                              <div className="h-2 w-[100px] rounded-lg bg-[#ecedef]" />
+                            </div>
+                          </div>
+                        </div>
+                        <span className="block w-full p-2 text-center font-normal">
+                          Light
+                        </span>
+                      </FormLabel>
+                    </FormItem>
+                    <FormItem>
+                      <FormLabel className="[&:has([data-state=checked])>div]:border-primary">
+                        <FormControl>
+                          <RadioGroupItem value="dark" className="sr-only" />
+                        </FormControl>
+                        <div className="items-center rounded-md border-2 border-muted bg-popover p-1 hover:bg-accent hover:text-accent-foreground">
+                          <div className="space-y-2 rounded-sm bg-slate-950 p-2">
+                            <div className="space-y-2 rounded-md bg-slate-800 p-2 shadow-sm">
+                              <div className="h-2 w-[80px] rounded-lg bg-slate-400" />
+                              <div className="h-2 w-[100px] rounded-lg bg-slate-400" />
+                            </div>
+                            <div className="flex items-center space-x-2 rounded-md bg-slate-800 p-2 shadow-sm">
+                              <div className="h-4 w-4 rounded-full bg-slate-400" />
+                              <div className="h-2 w-[100px] rounded-lg bg-slate-400" />
+                            </div>
+                            <div className="flex items-center space-x-2 rounded-md bg-slate-800 p-2 shadow-sm">
+                              <div className="h-4 w-4 rounded-full bg-slate-400" />
+                              <div className="h-2 w-[100px] rounded-lg bg-slate-400" />
+                            </div>
+                          </div>
+                        </div>
+                        <span className="block w-full p-2 text-center font-normal">
+                          Dark
+                        </span>
+                      </FormLabel>
+                    </FormItem>
+                    <FormItem>
+                      <FormLabel className="[&:has([data-state=checked])>div]:border-primary">
+                        <FormControl>
+                          <RadioGroupItem value="system" className="sr-only" />
+                        </FormControl>
+                        <div className="items-center rounded-md border-2 border-muted p-1 hover:border-accent">
+                          <div className="space-y-2 rounded-sm bg-gray-200 p-2 dark:bg-slate-950">
+                            <div className="space-y-2 rounded-md bg-white p-2 shadow-sm dark:bg-slate-800">
+                              <div className="h-2 w-[80px] rounded-lg bg-gray-300 dark:bg-slate-400" />
+                              <div className="h-2 w-[100px] rounded-lg bg-gray-300 dark:bg-slate-400" />
+                            </div>
+                            <div className="flex items-center space-x-2 rounded-md bg-white p-2 shadow-sm dark:bg-slate-800">
+                              <div className="h-4 w-4 rounded-full bg-gray-300 dark:bg-slate-400" />
+                              <div className="h-2 w-[100px] rounded-lg bg-gray-300 dark:bg-slate-400" />
+                            </div>
+                            <div className="flex items-center space-x-2 rounded-md bg-white p-2 shadow-sm dark:bg-slate-800">
+                              <div className="h-4 w-4 rounded-full bg-gray-300 dark:bg-slate-400" />
+                              <div className="h-2 w-[100px] rounded-lg bg-gray-300 dark:bg-slate-400" />
+                            </div>
+                          </div>
+                        </div>
+                        <span className="block w-full p-2 text-center font-normal">
+                          System
+                        </span>
+                      </FormLabel>
+                    </FormItem>
+                  </RadioGroup>
+                </FormItem>
+              )}
+            />
+            <Button type="submit">Update preferences</Button>
+          </form>
+        </Form>
+      </CardContent>
+    </Card>
+  )
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a full Settings experience with tabbed navigation: Profile, Appearance, and Notifications.
  * Profile tab includes Name and read-only Email fields with a Save action.
  * Appearance tab adds theme selection (Light, Dark, System) with immediate application and confirmation toast.
  * Notifications tab provides toggles for communication and marketing emails, plus a Save action.
  * Added a clearer header, descriptive subtitle, and visual separators for improved readability and navigation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->